### PR TITLE
Fixed an issue when adding a connection that requires Windows Authentication

### DIFF
--- a/Builder/CodeGenerationContext.cs
+++ b/Builder/CodeGenerationContext.cs
@@ -463,6 +463,8 @@ namespace OData4.Builder
                 {
                     var webRequest = (HttpWebRequest)WebRequest.Create(metadataUri);
                     webRequest.Proxy = LINQPad.Util.GetWebProxy();
+                    webRequest.Credentials = CredentialCache.DefaultCredentials;
+
                     var webResponse = webRequest.GetResponse();
                     metadataStream = webResponse.GetResponseStream();
                 }

--- a/OData4DynamicDriver.cs
+++ b/OData4DynamicDriver.cs
@@ -44,7 +44,7 @@ namespace OData4
             return cxInfo.DatabaseInfo.Server;
         }
 
-        public override Version Version => new Version("1.0.1.0");
+        public override Version Version => new Version("1.0.2.0");
 
         public override ParameterDescriptor[] GetContextConstructorParameters(IConnectionInfo cxInfo)
         {
@@ -145,7 +145,16 @@ namespace OData4
             };
 
             var metadataUri = context.GetMetadataUri();
-            using (var reader = XmlReader.Create(metadataUri.ToString()))
+
+            var settings = new XmlReaderSettings
+            {
+                XmlResolver = new XmlSecureResolver(new XmlUrlResolver(), metadataUri.ToString())
+                {
+                    Credentials = GetCredentials(cxInfo)
+                }
+            };
+
+            using (var reader = XmlReader.Create(metadataUri.ToString(), settings))
             {
                 model = EdmxReader.Parse(reader);
             }

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.1.0")]
-[assembly: AssemblyFileVersion("1.0.1.0")]
+[assembly: AssemblyVersion("1.0.2.0")]
+[assembly: AssemblyFileVersion("1.0.2.0")]


### PR DESCRIPTION
I fixed the issue when adding a connection that requires Windows Authentication.
I tested with the default odata service, a service that supports basic authentication and a service that requires Windows Authentication and all tests were successful.
